### PR TITLE
Reduced jest coverage threshold for CICD testing purposes

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -8,7 +8,7 @@ export default {
   coverageProvider: 'v8',
   coverageThreshold: {
     global: {
-      branches: 70,
+      branches: 50,
       function: 80,
       lines: 80,
       statements: 80,


### PR DESCRIPTION
jest.config.ts:
Global branch coverage threshold reduced to 50 to test multi-stage pipelines in Jenkins.